### PR TITLE
Fixed two small mistakes.

### DIFF
--- a/Sections/Determinante.tex
+++ b/Sections/Determinante.tex
@@ -11,7 +11,7 @@
 \end{itemize}
 
 \subsection{Gauss}
-Summe von allen Pivot-Elemente welche herausgenommen (dividiert) wurden. \textit{Achtung}: Bei Zeilen tauschen Summe mit (-1) Multiplizieren!
+Summe von allen Pivot-Elemente welche herausgenommen (dividiert) wurden. \textit{Achtung}: Bei Zeilen tauschen Produkt mit (-1) Multiplizieren!
 \[
 	\begin{vmatrix}
 		\circledr{2} & 2 & 4 \\

--- a/Sections/Einführung.tex
+++ b/Sections/Einführung.tex
@@ -225,7 +225,7 @@ Es gibt $\infty$-Lösungen, eine zB bei $\lambda_3 = 1; \lambda_2 = -2; \lambda_
 	\item $(A^{-1})^{-1} = A$
 	\item $(k \cdot A)^{-1} = k^{-1} \cdot A^{-1}$ (Skalar $k \neq 0$)
 	\item $(Ax)^T = x^TA^T$
-	\item $AA^T = E$
+	\item $AA^{-1} = E$
 	\item $A(\lambda x) = \lambda(Ax)$
 	\item $A(x + y) = Ax + Ay$
 \end{itemize}


### PR DESCRIPTION
- Das Multiplizieren von Werten ist ein Produkt, keine Summe.
- Die Einheitsmatrix ergibt sich durch AA^{-1} und nicht AA^T, siehe [Wikipedia](https://de.wikipedia.org/wiki/Inverse_Matrix#Beispiele)